### PR TITLE
Remove the available portions from a dish and Change domain rules for available dish portions to the servings recoun

### DIFF
--- a/prisma/migrations/20250811091747_change_fecha_to_db_timestamptz/migration.sql
+++ b/prisma/migrations/20250811091747_change_fecha_to_db_timestamptz/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Pedido" ALTER COLUMN "fecha" SET DATA TYPE TIMESTAMPTZ(6);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,7 +79,7 @@ model Cliente {
 
 model Pedido {
   id              Int              @id @default(autoincrement())
-  fecha           DateTime         @db.Timestamp(6)
+  fecha           DateTime         @db.Timestamptz(6)
   estado          EstadoPedido     @default(PENDIENTE)
   tipoEntrega     TipoEntrega      @default(PRESENCIAL)
   tipoPago        TipoPago         @default(EFECTIVO)

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,7 @@ function main(){
     );
 
     // Inicializar tareas programadas
-    CronJobs.executeRationsLoad();
+    // CronJobs.executeRationsLoad();
 
     // Configurar y iniciar el servidor.
     const server = new AppServer({

--- a/src/configuration/plugins/luxon.adapter.ts
+++ b/src/configuration/plugins/luxon.adapter.ts
@@ -10,6 +10,10 @@ export const luxonAdapter = {
     return dt.startOf('day');
   },
 
+  getEndOfDay: (dt: DateTime): DateTime => {
+    return dt.endOf('day');
+  },
+
   getDayName: (dt: DateTime): 'DOMINGO' | 'LUNES' | 'MARTES' | 'MIERCOLES' | 'JUEVES' | 'VIERNES' | 'SABADO' => {
     const diasEnum = [
       'DOMINGO', 'LUNES', 'MARTES', 'MIERCOLES', 'JUEVES', 'VIERNES', 'SABADO'

--- a/src/configuration/plugins/luxon.adapter.ts
+++ b/src/configuration/plugins/luxon.adapter.ts
@@ -1,34 +1,35 @@
 import { DateTime } from 'luxon';
+import { CustomError } from '../../domain/errors';
+import { WeekDays } from '../../domain/entities';
 
 export const luxonAdapter = {
+  getCurrentDateTimeInZone: (zone: string = 'America/Merida'): DateTime => 
+    DateTime.now().setZone(zone),
 
-  getCurrentDateTimeInYucatan: (zone: string = 'America/Merida'): DateTime => {
-    return DateTime.now().setZone(zone);
-  },
+  getStartOfDayUtc: (zone: string): DateTime => 
+    DateTime.now().setZone(zone).startOf('day').toUTC(),
 
-  getStartOfDay: (dt: DateTime): DateTime => {
-    return dt.startOf('day');
-  },
+  getEndOfDayUtc: (zone: string): DateTime => 
+    DateTime.now().setZone(zone).endOf('day').toUTC(),
 
-  getEndOfDay: (dt: DateTime): DateTime => {
-    return dt.endOf('day');
-  },
-
-  getDayName: (dt: DateTime): 'DOMINGO' | 'LUNES' | 'MARTES' | 'MIERCOLES' | 'JUEVES' | 'VIERNES' | 'SABADO' => {
-    const diasEnum = [
+  getDayName: (dt: DateTime): WeekDays => {
+    const diasEnum: WeekDays[] = [
       'DOMINGO', 'LUNES', 'MARTES', 'MIERCOLES', 'JUEVES', 'VIERNES', 'SABADO'
-    ] as const;
-
-    // Luxon: weekday 1 = Monday, 7 = Sunday, así que ajustamos con módulo
+    ];
     return diasEnum[dt.weekday % 7];
   },
 
-  toJSDate: (dt: DateTime): Date => {
-    return dt.toJSDate();
-  },
+  toJSDate: (dt: DateTime): Date => dt.toJSDate(),
 
-  formatDateTime: (dt: DateTime, format = 'ff'): string => {
-    return dt.toFormat(format); // ejemplo de formato: 'yyyy-MM-dd HH:mm:ss'
+  /** Nuevo método limpio y único propósito */
+  getDayRangeUtcByZone: (zone: string): { startUTC: Date; endUTC: Date; dayName: WeekDays } => {
+    const startDT = luxonAdapter.getStartOfDayUtc(zone);
+    const endDT = luxonAdapter.getEndOfDayUtc(zone);
+
+    return {
+      startUTC: luxonAdapter.toJSDate(startDT),
+      endUTC: luxonAdapter.toJSDate(endDT),
+      dayName: luxonAdapter.getDayName(startDT)
+    };
   }
-
-}
+};

--- a/src/configuration/regular-exp.ts
+++ b/src/configuration/regular-exp.ts
@@ -5,4 +5,37 @@ export const regularExps = {
   email: /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/,
   password: /(?:(?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/,
 
+  /**
+ * Expresión regular para validar cadenas con formato ISO 8601 completo en UTC (sin zona horaria explícita, solo 'Z')
+ * Formato esperado:
+ *   YYYY-MM-DDThh:mm:ss[.sss]Z
+ *
+ * Donde:
+ *  - YYYY: año de 4 dígitos (ej. 2025)
+ *  - MM: mes de 2 dígitos (01 a 12) — *no valida rango real*
+ *  - DD: día de 2 dígitos (01 a 31) — *no valida rango real*
+ *  - T: separador literal
+ *  - hh: hora en formato 24h de 2 dígitos (00 a 23) — *no valida rango real*
+ *  - mm: minutos de 2 dígitos (00 a 59)
+ *  - ss: segundos de 2 dígitos (00 a 59)
+ *  - [.sss]: opcional, fracciones de segundo precedidas por punto
+ *  - Z: indica zona horaria UTC (obligatorio)
+ *
+ * Esta expresión sólo valida el formato, NO valida rangos reales de fecha y hora.
+ *
+ * Ejemplos que acepta (regresa true):
+ *   "2025-08-07T14:30:00Z"
+ *   "1999-12-31T23:59:59Z"
+ *   "2020-01-01T00:00:00.123Z"
+ *
+ * Ejemplos que NO acepta (regresa false):
+ *   "2025-8-7T14:30:00Z"          // mes y día no tienen 2 dígitos
+ *   "2025-08-07 14:30:00Z"        // falta la T
+ *   "2025-08-07T14:30:00"         // falta la Z final
+ *   "2025-08-07T14:30Z"           // faltan segundos
+ *   "2025-08-07T14:30:00+01:00"   // no acepta otras zonas horarias que no sean Z
+ *   "2025-13-40T99:99:99Z"        // aunque formato válido, valores no reales, pero pasa la regex
+ */
+  iso8601: /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+
 }

--- a/src/domain/datasource/order.datasource.ts
+++ b/src/domain/datasource/order.datasource.ts
@@ -16,4 +16,9 @@ export abstract class OrderDatasource {
   // orderDetail
   abstract createOrderDetail(orderDetail: CreateOrderDetailsDto): Promise<OrderDetail>;
   abstract deleteOrderDetail(orderDetailId: number): Promise<OrderDetail>;
+  abstract getOrderedServingsByDishAndDateRange(dishId: number, startDate: Date, endDate: Date): 
+  Promise<{
+    dishId: number,
+    dishTotalServings: number
+  }>;
 }

--- a/src/domain/dtos/order/create-order.dto.ts
+++ b/src/domain/dtos/order/create-order.dto.ts
@@ -1,3 +1,4 @@
+import { regularExps } from "../../../configuration/regular-exp";
 import { Order, OrderDeliveryType, OrderPaymentType, OrderStatus } from "../../entities";
 import { CreateOrderDetailsDto } from "./create-order-details.dto";
 
@@ -18,8 +19,11 @@ export class CreateOrderDto {
 
     // Validar fecha
     if (!date) return ['date is required'];
+
+    if (!regularExps.iso8601.test(date)) return ['date must be in ISO 8601 format - example: 2023-10-01T12:00:00Z'];
+
     const newDate = new Date(date);
-    if (isNaN(newDate.getTime())) return ['date is not a valid date - format: yyyy-mm-dd hh:mm:ss'];
+    if (isNaN(newDate.getTime())) return ['date is not a valid date - example: 2023-10-01T12:00:00Z'];
 
     // Validar estado del pedido
     if (!status) return ['status is required'];

--- a/src/domain/entities/sched-dish.entity.ts
+++ b/src/domain/entities/sched-dish.entity.ts
@@ -13,7 +13,8 @@ export class SchedDish {
     public dishId: number,
     public kitchenId: number,
     public weekDay: WeekDays,
-    public scheduledRations: number,
+    public SchedDishPortionLimit?: number,
+    public controlRations: boolean = false,
     public dish?: Dish
   ){}
 
@@ -22,20 +23,25 @@ export class SchedDish {
   }
 
   static fromJson( object: {[key: string] : any} ): SchedDish {
-    const { id, platilloId, cocinaId, diaSemana, racionesProgramadas, platillo } = object;
+    const { id, platilloId, cocinaId, diaSemana, /* racionesProgramadas,  */platillo, limiteRaciones, controlRaciones } = object;
 
     if (!diaSemana) throw CustomError.badRequest('Missing diaSemana');
     if (!SchedDish.isValidWeekDay(diaSemana)) throw CustomError.badRequest (`Invalid week day: ${diaSemana}, valid values: ${SchedDish.validWeekDays}`);
     if (!id) throw CustomError.badRequest('Missing id');
     if (!platilloId) throw CustomError.badRequest('Missing platilloId');
     if (!cocinaId) throw CustomError.badRequest('Missing cocinaId');
-    if (!racionesProgramadas) throw CustomError.badRequest('Missing racionesProgramadas');
-    if (typeof racionesProgramadas !== 'number') throw CustomError.badRequest('racionesProgramadas must be a number');
-    if (racionesProgramadas < 0) throw CustomError.badRequest('racionesProgramadas must be greater than 0');
+    if (limiteRaciones) {
+      if (isNaN(limiteRaciones)) throw CustomError.badRequest('limiteRaciones must be a number');
+      if (limiteRaciones < 0) throw CustomError.badRequest('limiteRaciones must be greater than 0');
+    }
+    if (controlRaciones !== undefined && typeof controlRaciones !== 'boolean') throw CustomError.badRequest('controlRaciones must be a boolean');
+    // if (!racionesProgramadas) throw CustomError.badRequest('Missing racionesProgramadas');
+    // if (typeof racionesProgramadas !== 'number') throw CustomError.badRequest('racionesProgramadas must be a number');
+    // if (racionesProgramadas < 0) throw CustomError.badRequest('racionesProgramadas must be greater than 0');
     // Convertir el objeto platillo a una instancia de Dish si está presente
     const dish = platillo ? Dish.fromJson(platillo) : undefined;
 
-    return new SchedDish( id, platilloId, cocinaId, diaSemana, racionesProgramadas, dish );
+    return new SchedDish( id, platilloId, cocinaId, diaSemana, limiteRaciones, controlRaciones, dish);
   }
 
 }

--- a/src/domain/repositories/order.repository.ts
+++ b/src/domain/repositories/order.repository.ts
@@ -16,4 +16,9 @@ export abstract class OrderRepository {
   // orderDetail
   abstract createOrderDetail(orderDetail: CreateOrderDetailsDto): Promise<OrderDetail>;
   abstract deleteOrderDetail(orderDetailId: number): Promise<OrderDetail>;
+  abstract getOrderedServingsByDishAndDateRange(dishId: number, startDate: Date, endDate: Date): 
+  Promise<{
+    dishId: number,
+    dishTotalServings: number
+  }>;
 }

--- a/src/domain/use-cases/dish/get-available-dishes.ts
+++ b/src/domain/use-cases/dish/get-available-dishes.ts
@@ -1,6 +1,6 @@
 import { luxonAdapter } from "../../../configuration/plugins/luxon.adapter";
 import { User } from "../../entities";
-import { SchedDishRepository } from "../../repositories/sched-dish.repository";
+import { SchedDishRepository, OrderRepository } from "../../repositories/index";
 
 interface GetAvailableDishesUseCase {
   execute(user: User): Promise<object>;
@@ -10,6 +10,7 @@ export class GetAvailableDishes implements GetAvailableDishesUseCase {
 
   constructor(
     private readonly schedDishRepository: SchedDishRepository,
+    private readonly orderRepository: OrderRepository
   ) {}
 
   async execute(user: User): Promise<object> {
@@ -17,34 +18,65 @@ export class GetAvailableDishes implements GetAvailableDishesUseCase {
     //día de la semana actual.
     const nowInZone = luxonAdapter.getCurrentDateTimeInYucatan('America/Merida');
     const startOfDay = luxonAdapter.getStartOfDay(nowInZone);
+    const endOfDay = luxonAdapter.getEndOfDay(nowInZone);
     const today = luxonAdapter.getDayName(startOfDay);
+
+    const startJSDate = luxonAdapter.toJSDate(startOfDay);
+    const endJSDate = luxonAdapter.toJSDate(endOfDay);
 
     //Si es super admin, se le devuelven todos los platillos programados de todas las cocinas.
     if(user.rol === 'SUPER_ADMIN') {
+
       const allScheduledDishes = await this.schedDishRepository.findScheduledDishesByDay(today);
-      const result = allScheduledDishes.map(({ dish }) => ({
-        id: dish!.dishId,
-        nombre: dish!.name,
-        rutaImagen: dish?.imagePath,
-        precioMedia: dish!.pricePerHalfServing,
-        precioEntera: dish!.pricePerServing,
-        /* racionesDisponibles: dish!.availableServings, */
-      }));
-      return {dia: today, platillos: result};
+
+      const superAdminResult = await Promise.all(
+
+        allScheduledDishes.map( async ({ dish }) => { //puedo ejecutar una funcion asincrona dentro de un map, pero debo retornar una promesa.
+          
+          //esto me trae todos los orderDetails de ese platillo en el rango de fechas.
+          const orderDetailsFromDishId = await this.orderRepository.getOrderedServingsByDishAndDateRange(dish!.dishId, startJSDate, endJSDate);
+
+          return { //Esteo es lo que se va a retornar en el map y el promise.all lo va a resolver.
+            id: dish!.dishId,
+            nombre: dish!.name,
+            rutaImagen: dish?.imagePath,
+            precioMedia: dish!.pricePerHalfServing,
+            precioEntera: dish!.pricePerServing,
+            recuentoPorciones : orderDetailsFromDishId.dishTotalServings,
+          }
+        })
+
+      );
+
+      return {dia: today, platillos: superAdminResult};
+
     }
 
     const scheduledDishes = await this.schedDishRepository.findAllSchedDishByKitchen(user.kitchenId!, today);
 
-    const result = scheduledDishes.map(({ dish }) => ({
-      id: dish!.dishId,
-      nombre: dish!.name,
-      rutaImagen: dish?.imagePath,
-      precioMedia: dish!.pricePerHalfServing,
-      precioEntera: dish!.pricePerServing,
-      // racionesDisponibles: dish!.availableServings,
-    }));
+    const usersResult = await Promise.all(
 
-    return {dia: today, platillos: result};
+        scheduledDishes.map( async ({ dish }) => { //puedo ejecutar una funcion asincrona dentro de un map, pero debo retornar una promesa.
+          
+          //esto me trae todos los orderDetails de ese platillo en el rango de fechas.
+          const orderDetailsFromDishId = await this.orderRepository.getOrderedServingsByDishAndDateRange(dish!.dishId, startJSDate, endJSDate);
+
+          return { //Esteo es lo que se va a retornar en el map y el promise.all lo va a resolver.
+            id: dish!.dishId,
+            nombre: dish!.name,
+            rutaImagen: dish?.imagePath,
+            precioMedia: dish!.pricePerHalfServing,
+            precioEntera: dish!.pricePerServing,
+            recuentoPorciones : orderDetailsFromDishId.dishTotalServings,
+          }
+        })
+
+      );
+
+      return {
+        dia: today, 
+        platillos: usersResult
+      };
   }
 
 }

--- a/src/domain/use-cases/dish/get-available-dishes.ts
+++ b/src/domain/use-cases/dish/get-available-dishes.ts
@@ -1,83 +1,67 @@
 import { luxonAdapter } from "../../../configuration/plugins/luxon.adapter";
-import { User } from "../../entities";
+import { Dish, User, WeekDays } from "../../entities";
 import { SchedDishRepository, OrderRepository } from "../../repositories/index";
 
+interface AvailableDishDto {
+  id: number;
+  nombre: string;
+  rutaImagen?: string;
+  precioMedia: number;
+  precioEntera: number;
+  recuentoPorciones: number;
+}
+
+interface GetAvailableDishesResult {
+  dia: WeekDays;
+  platillos: AvailableDishDto[];
+}
+
 interface GetAvailableDishesUseCase {
-  execute(user: User): Promise<object>;
+  execute(user: User): Promise<GetAvailableDishesResult>;
 }
 
 export class GetAvailableDishes implements GetAvailableDishesUseCase {
-
   constructor(
     private readonly schedDishRepository: SchedDishRepository,
     private readonly orderRepository: OrderRepository
   ) {}
 
-  async execute(user: User): Promise<object> {
-    
-    //día de la semana actual.
-    const nowInZone = luxonAdapter.getCurrentDateTimeInYucatan('America/Merida');
-    const startOfDay = luxonAdapter.getStartOfDay(nowInZone);
-    const endOfDay = luxonAdapter.getEndOfDay(nowInZone);
-    const today = luxonAdapter.getDayName(startOfDay);
+  async execute(user: User): Promise<GetAvailableDishesResult> {
+    const userDayRangeUTC = luxonAdapter.getDayRangeUtcByZone("America/Merida");
 
-    const startJSDate = luxonAdapter.toJSDate(startOfDay);
-    const endJSDate = luxonAdapter.toJSDate(endOfDay);
+    const scheduledDishes = await this.getScheduledDishes(user, userDayRangeUTC.dayName);
 
-    //Si es super admin, se le devuelven todos los platillos programados de todas las cocinas.
-    if(user.rol === 'SUPER_ADMIN') {
+    const availableDishes = await Promise.all(
+      scheduledDishes.map((scheduledDish) => this.mapToAvailableDish(scheduledDish.dish!, userDayRangeUTC))
+    );
 
-      const allScheduledDishes = await this.schedDishRepository.findScheduledDishesByDay(today);
-
-      const superAdminResult = await Promise.all(
-
-        allScheduledDishes.map( async ({ dish }) => { //puedo ejecutar una funcion asincrona dentro de un map, pero debo retornar una promesa.
-          
-          //esto me trae todos los orderDetails de ese platillo en el rango de fechas.
-          const orderDetailsFromDishId = await this.orderRepository.getOrderedServingsByDishAndDateRange(dish!.dishId, startJSDate, endJSDate);
-
-          return { //Esteo es lo que se va a retornar en el map y el promise.all lo va a resolver.
-            id: dish!.dishId,
-            nombre: dish!.name,
-            rutaImagen: dish?.imagePath,
-            precioMedia: dish!.pricePerHalfServing,
-            precioEntera: dish!.pricePerServing,
-            recuentoPorciones : orderDetailsFromDishId.dishTotalServings,
-          }
-        })
-
-      );
-
-      return {dia: today, platillos: superAdminResult};
-
-    }
-
-    const scheduledDishes = await this.schedDishRepository.findAllSchedDishByKitchen(user.kitchenId!, today);
-
-    const usersResult = await Promise.all(
-
-        scheduledDishes.map( async ({ dish }) => { //puedo ejecutar una funcion asincrona dentro de un map, pero debo retornar una promesa.
-          
-          //esto me trae todos los orderDetails de ese platillo en el rango de fechas.
-          const orderDetailsFromDishId = await this.orderRepository.getOrderedServingsByDishAndDateRange(dish!.dishId, startJSDate, endJSDate);
-
-          return { //Esteo es lo que se va a retornar en el map y el promise.all lo va a resolver.
-            id: dish!.dishId,
-            nombre: dish!.name,
-            rutaImagen: dish?.imagePath,
-            precioMedia: dish!.pricePerHalfServing,
-            precioEntera: dish!.pricePerServing,
-            recuentoPorciones : orderDetailsFromDishId.dishTotalServings,
-          }
-        })
-
-      );
-
-      return {
-        dia: today, 
-        platillos: usersResult
-      };
+    return {
+      dia: userDayRangeUTC.dayName,
+      platillos: availableDishes,
+    };
   }
 
+  private async  getScheduledDishes(user: User, dayName: WeekDays) {
+    if (user.rol === "SUPER_ADMIN") {
+      return this.schedDishRepository.findScheduledDishesByDay(dayName);
+    }
+    return this.schedDishRepository.findAllSchedDishByKitchen(user.kitchenId!, dayName);
+  }
+
+  private async mapToAvailableDish(dish: Dish, range: { startUTC: Date; endUTC: Date }): Promise<AvailableDishDto> {
+    const orders = await this.orderRepository.getOrderedServingsByDishAndDateRange(
+      dish.dishId,
+      range.startUTC,
+      range.endUTC
+    );
+
+    return {
+      id: dish.dishId,
+      nombre: dish.name,
+      rutaImagen: dish.imagePath,
+      precioMedia: dish.pricePerHalfServing,
+      precioEntera: dish.pricePerServing,
+      recuentoPorciones: orders.dishTotalServings,
+    };
+  }
 }
-  

--- a/src/domain/use-cases/dish/loading-daily-rations.ts
+++ b/src/domain/use-cases/dish/loading-daily-rations.ts
@@ -1,44 +1,44 @@
-import { DishRepository, SchedDishRepository } from '../../repositories';
-import { UpdateDishDto } from '../../dtos';
-import { luxonAdapter } from '../../../configuration/plugins/luxon.adapter';
+// import { DishRepository, SchedDishRepository } from '../../repositories';
+// import { UpdateDishDto } from '../../dtos';
+// import { luxonAdapter } from '../../../configuration/plugins/luxon.adapter';
 
-interface LoadingDailyRationsUseCase {
-  execute(): Promise<void>;
-}
+// interface LoadingDailyRationsUseCase {
+//   execute(): Promise<void>;
+// }
 
-export class LoadingDailyRations implements LoadingDailyRationsUseCase {
+// export class LoadingDailyRations implements LoadingDailyRationsUseCase {
 
-  constructor(
-    private readonly schedDishRespository: SchedDishRepository,
-    private readonly dishRepository: DishRepository
-  ) {}
+//   constructor(
+//     private readonly schedDishRespository: SchedDishRepository,
+//     private readonly dishRepository: DishRepository
+//   ) {}
 
-  async execute() {
-    const nowInZone = luxonAdapter.getCurrentDateTimeInYucatan('America/Merida');
-    const startOfDay = luxonAdapter.getStartOfDay(nowInZone);
-    const today = luxonAdapter.getDayName(startOfDay);
+//   async execute() {
+//     const nowInZone = luxonAdapter.getCurrentDateTimeInZone('America/Merida');
+//     const startOfDay = luxonAdapter.getStartOfDay(nowInZone);
+//     const today = luxonAdapter.getDayName(startOfDay);
 
-    // console.log(`📅 Hoy en Yucatán es: ${today} (${luxonAdapter.formatDateTime(nowInZone)})`);
+//     // console.log(`📅 Hoy en Yucatán es: ${today} (${luxonAdapter.formatDateTime(nowInZone)})`);
 
-    const platillosProgramados = await this.schedDishRespository.findScheduledDishesByDay(today);
+//     const platillosProgramados = await this.schedDishRespository.findScheduledDishesByDay(today);
 
-    for (const p of platillosProgramados) { //*Por cada platillo programado, actualizamos las raciones disponibles.*/
-      console.log(`Platillo programado: ${p}`);
-      const updateDishDto = new UpdateDishDto(
-        p.dishId,
-        undefined,
-        undefined, 
-        undefined,
-        undefined,
-        undefined,
-      );
+//     for (const p of platillosProgramados) { //*Por cada platillo programado, actualizamos las raciones disponibles.*/
+//       console.log(`Platillo programado: ${p}`);
+//       const updateDishDto = new UpdateDishDto(
+//         p.dishId,
+//         undefined,
+//         undefined, 
+//         undefined,
+//         undefined,
+//         undefined,
+//       );
 
-      await this.dishRepository.updateDish(updateDishDto); // Actualiza la ración disponible del platillo en la cocina.
-      // console.log(
-      //   `📦 Platillo "${p.dish?.name}" en cocina ID ${p.kitchenId} programado con ${p.dish?.availableServings} raciones.`
-      // );
-    }
+//       await this.dishRepository.updateDish(updateDishDto); // Actualiza la ración disponible del platillo en la cocina.
+//       // console.log(
+//       //   `📦 Platillo "${p.dish?.name}" en cocina ID ${p.kitchenId} programado con ${p.dish?.availableServings} raciones.`
+//       // );
+//     }
 
-    // console.log('✅ Raciones del día cargadas correctamente.');
-  }
-}
+//     // console.log('✅ Raciones del día cargadas correctamente.');
+//   }
+// }

--- a/src/domain/use-cases/dish/loading-daily-rations.ts
+++ b/src/domain/use-cases/dish/loading-daily-rations.ts
@@ -29,7 +29,6 @@ export class LoadingDailyRations implements LoadingDailyRationsUseCase {
         undefined,
         undefined, 
         undefined,
-        p.scheduledRations,
         undefined,
         undefined,
       );

--- a/src/domain/use-cases/order/create-order.ts
+++ b/src/domain/use-cases/order/create-order.ts
@@ -42,7 +42,7 @@ export class RegisterOrder implements RegisterOrderUseCase {
           );
         }
         // validar que ese platillo tenga suficientes raciones disponibles
-        const orderPortion = detail.fullPortion + detail.halfPortion * 0.5;
+        // const orderPortion = detail.fullPortion + detail.halfPortion * 0.5;
         //TODO: Cuando el control de raciones de PlatilloProgramado este activo. Validar que orderPortion no sea mayor al limiteRaciones de PlatilloProgramado
         // if (dish.availableServings < orderPortion) {
         //   throw CustomError.unAuthorized(

--- a/src/infrastructure/repository/order.repository.impl.ts
+++ b/src/infrastructure/repository/order.repository.impl.ts
@@ -56,4 +56,12 @@ export class OrderRepositoryImpl implements OrderRepository{
   getOrdersByKitchenId(kitchenId: number, pagination: PaginationDto): Promise<Order[]> {
     return this.datasource.getOrdersByKitchenId(kitchenId, pagination);
   }
+
+  getOrderedServingsByDishAndDateRange(dishId: number, startDate: Date, endDate: Date): 
+  Promise<{
+    dishId: number,
+    dishTotalServings: number
+  }> {
+    return this.datasource.getOrderedServingsByDishAndDateRange(dishId, startDate, endDate);
+  }
 }

--- a/src/presentation/cron-jobs.ts
+++ b/src/presentation/cron-jobs.ts
@@ -4,25 +4,25 @@ import { PostgresSchedDishDataSourceImpl, PostgresDishDatasourceImpl } from '../
 import { SchedDishRepositoryImpl, DishRepositoryImpl } from '../infrastructure/repository';
 
 export class CronJobs {
-  static executeRationsLoad() {
-    // Configurar el cron job para cargar raciones diarias
-    CronService.createCronJob(
-      // '* * * * *', // Ejecutar cada minuto (para pruebas)
-      // '0 5 * * *', // Ejecutar todos los días a las 5:00 AM
-      '49 0 * * *', // Ejecutar todos los días a las 12:40 AM//ejecutar a las 12:40 am. 
-      async () => {
-        // console.log('⏰ Ejecutando cron para cargar raciones del día...');
+  // static executeRationsLoad() {
+  //   // Configurar el cron job para cargar raciones diarias
+  //   CronService.createCronJob(
+  //     // '* * * * *', // Ejecutar cada minuto (para pruebas)
+  //     // '0 5 * * *', // Ejecutar todos los días a las 5:00 AM
+  //     '49 0 * * *', // Ejecutar todos los días a las 12:40 AM//ejecutar a las 12:40 am. 
+  //     async () => {
+  //       // console.log('⏰ Ejecutando cron para cargar raciones del día...');
         
-        // Instanciar dependencias necesarias
-        const schedDishDatasource = new PostgresSchedDishDataSourceImpl();
-        const dishDatasource = new PostgresDishDatasourceImpl();
+  //       // Instanciar dependencias necesarias
+  //       const schedDishDatasource = new PostgresSchedDishDataSourceImpl();
+  //       const dishDatasource = new PostgresDishDatasourceImpl();
         
-        const schedDishRepository = new SchedDishRepositoryImpl(schedDishDatasource);
-        const dishRepository = new DishRepositoryImpl(dishDatasource);
+  //       const schedDishRepository = new SchedDishRepositoryImpl(schedDishDatasource);
+  //       const dishRepository = new DishRepositoryImpl(dishDatasource);
 
-        // Ejecutar el caso de uso
-        await new LoadingDailyRations(schedDishRepository, dishRepository).execute();
-      }
-    );
-  }
+  //       // Ejecutar el caso de uso
+  //       await new LoadingDailyRations(schedDishRepository, dishRepository).execute();
+  //     }
+  //   );
+  // }
 }

--- a/src/presentation/dish/sched-dish-controller.ts
+++ b/src/presentation/dish/sched-dish-controller.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import { CreateSchedDishDto } from "../../domain/dtos";
 import { CreateSchedDish } from "../../domain/use-cases/dish/create-sched-dish";
 import { CustomError } from "../../domain/errors";
-import { DishRepository, SchedDishRepository } from "../../domain/repositories";
+import { DishRepository, SchedDishRepository, OrderRepository } from "../../domain/repositories";
 import { GetAvailableDishes } from '../../domain/use-cases/dish/get-available-dishes';
 import { User } from "../../domain/entities";
 
@@ -11,6 +11,7 @@ export class SchedDishController {
   constructor(
     private readonly dishRepository: DishRepository,
     private readonly schedDishRepository: SchedDishRepository,
+    private readonly orderRepository: OrderRepository,
   ){}
 
   private handleError(error: unknown, res: Response) {
@@ -43,7 +44,10 @@ export class SchedDishController {
     
     const user = req.body.user as User;
 
-    new GetAvailableDishes(this.schedDishRepository)
+    new GetAvailableDishes(
+      this.schedDishRepository,
+      this.orderRepository
+    )
     .execute(user)
     .then( availableDishes => res.status(200).json(availableDishes))
     .catch( error => this.handleError(error, res));

--- a/src/presentation/dish/sched-dish-routes.ts
+++ b/src/presentation/dish/sched-dish-routes.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { SchedDishController } from "./sched-dish-controller";
 import { AuthMiddleware } from '../middlewares/auth.middleware';
-import { PostgresDishDatasourceImpl, PostgresSchedDishDataSourceImpl, PostgresUserDataSourceImpl } from "../../infrastructure/datasource";
-import { DishRepositoryImpl, SchedDishRepositoryImpl, UserRepositoryImpl } from "../../infrastructure/repository";
+import { PostgresDishDatasourceImpl, PostgresOrderDatasourceImpl, PostgresSchedDishDataSourceImpl, PostgresUserDataSourceImpl } from "../../infrastructure/datasource";
+import { DishRepositoryImpl, OrderRepositoryImpl, SchedDishRepositoryImpl, UserRepositoryImpl } from "../../infrastructure/repository";
 import { rolesConfig } from "../../configuration";
 
 export class SchedDishRoutes {
@@ -17,13 +17,17 @@ export class SchedDishRoutes {
     
     const schedDishDatasourceImpl = new PostgresSchedDishDataSourceImpl();
     const schedDishRepositoryImpl = new SchedDishRepositoryImpl(schedDishDatasourceImpl);
-    
+
+    const orderDatasourceImpl = new PostgresOrderDatasourceImpl();
+    const orderRepositoryImpl = new OrderRepositoryImpl(orderDatasourceImpl);
+
     const authMiddleware = new AuthMiddleware(userRepositoryImpl);
     const roles = rolesConfig;
     
     const schedDishController = new SchedDishController(
       dishRepositoryImpl,
-      schedDishRepositoryImpl
+      schedDishRepositoryImpl,
+      orderRepositoryImpl
     );
 
     router.post(


### PR DESCRIPTION
return totalServingsFromDish from get available-dishes
1. create getEndOfDay in LuxonAdapter.
2. create getOrderedServingsByDishAndDateRange in datasorce and repository from infrastructure and domain.
3.  update sched dish entity to the new domain rules.
4. implement getOrderedServingsByDishAndDateRange in get-available-dishes

Change domain rules for available dish portions

1. previously, the available portions were displayed.
2. now, the servings recount are displayed.
3. the schema, datasource, domain are adapted to reflect this change.